### PR TITLE
Update regex for Gerrit 2.15

### DIFF
--- a/handlers/message_handler.py
+++ b/handlers/message_handler.py
@@ -23,7 +23,7 @@ def process_message(m):
                     break
                 number += 1
                 topic = re.search(r'(?:topic:)(.+?(?:(?=[%\s+]|$|>)))',word)
-                change = re.search(r'(?:' + gerrit_url.replace('.', r'\.') + ')(?:(?:#\/c\/)|)([0-9]{4,7})',word)
+                change = re.search(r'(?:' + gerrit_url.replace('.', r'\.') + ')(?:(?:#\/c\/)|)(?:LineageOS\/[a-zA-Z_0-9\-]*\/\+\/)([0-9]{4,7})',word)
                 if change:
                     response.append(GerritChangeFetcher.get_change(change.group(1)))
                 elif topic:


### PR DESCRIPTION
Project paths now present in URL, but old URLs can still be used so use
non-capture group