### PR TITLE
Unbreak gerrit regexp

### DIFF
--- a/handlers/message_handler.py
+++ b/handlers/message_handler.py
@@ -33,7 +33,7 @@ def process_message(event, client):
                         break
                     number += 1
                     topic = re.search(r'(?:topic:)(.+?(?:(?=[%\s+]|$|>)))',word)
-                    change = re.search(r'(?:' + gerrit_url.replace('.', r'\.') + ')(?:(?:#\/c\/)|)(?:LineageOS\/[a-zA-Z_0-9\-]*\/\+\/)([0-9]{4,7})',word)
+                    change = re.search(gerrit_url.replace('.', r'\.') + '(?:(?:#\/)?c\/(?:LineageOS\/[a-zA-Z_0-9\-]*\/\+\/)?)?([0-9]+)',word)
                     if change:
                         attachments.append(GerritChangeFetcher.get_change(change.group(1)))
                     elif topic:


### PR DESCRIPTION
Unbreak the regexp for old-format Gerrit links (without the project
path) by making that specific group optional when matching.

Also, properly nest those regexp groups (Base URL -> "#/c/" -> project
path) to get rid of vertical lines (which are a hacky way to allow it
to match "").

While we're at it, remove the limit of digits in the change number.